### PR TITLE
Fix Slack links and BigQuery typo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -9,7 +9,7 @@ body:
 
         🚨 Reporting a security issue: send an email to security@superset.apache.org. DO NOT USE GITHUB ISSUES TO REPORT SECURITY PROBLEMS.
         🐛 Reporting a bug: use this form.
-        🙏 Asking a question or getting help: post in the [Superset Slack chat](http://bit.ly/join-superset-slack) or [GitHub Discussions](https://github.com/apache/superset/discussions) under "Q&A / Help".
+        🙏 Asking a question or getting help: post in the [Superset Slack chat](https://bit.ly/join-superset-slack) or [GitHub Discussions](https://github.com/apache/superset/discussions) under "Q&A / Help".
         💡 Requesting a new feature: Search [GitHub Discussions](https://github.com/apache/superset/discussions) to see if it exists already. If not, add a new post there under "Ideas".
   - type: textarea
     id: bug-description

--- a/.github/workflows/welcome-new-users.yml
+++ b/.github/workflows/welcome-new-users.yml
@@ -19,4 +19,4 @@ jobs:
           pr-message: |-
             Congrats on making your first PR and thank you for contributing to Superset! :tada: :heart:
 
-            We hope to see you in our [Slack](https://apache-superset.slack.com/) community too! Not signed up? Use our [Slack App](http://bit.ly/join-superset-slack) to self-register.
+              We hope to see you in our [Slack](https://apache-superset.slack.com/) community too! Not signed up? Use our [Slack App](https://bit.ly/join-superset-slack) to self-register.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -105,7 +105,7 @@ This statement thanks the following, on which it draws for content and inspirati
 
 # Slack Community Guidelines
 
-If you decide to join the [Community Slack](http://bit.ly/join-superset-slack), please adhere to the following rules:
+If you decide to join the [Community Slack](https://bit.ly/join-superset-slack), please adhere to the following rules:
 
 **1. Treat everyone in the community with respect.**
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ under the License.
 [![PyPI version](https://badge.fury.io/py/apache-superset.svg)](https://badge.fury.io/py/apache-superset)
 [![Coverage Status](https://codecov.io/github/apache/superset/coverage.svg?branch=master)](https://codecov.io/github/apache/superset)
 [![PyPI](https://img.shields.io/pypi/pyversions/apache-superset.svg?maxAge=2592000)](https://pypi.python.org/pypi/apache-superset)
-[![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](http://bit.ly/join-superset-slack)
+[![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](https://bit.ly/join-superset-slack)
 [![Documentation](https://img.shields.io/badge/docs-apache.org-blue.svg)](https://superset.apache.org)
 
 <picture width="500">
@@ -101,7 +101,7 @@ Here are some of the major database solutions that are supported:
 
 <p align="center">
   <img src="https://superset.apache.org/img/databases/redshift.png" alt="redshift" border="0" width="200"/>
-  <img src="https://superset.apache.org/img/databases/google-biquery.png" alt="google-biquery" border="0" width="200"/>
+  <img src="https://superset.apache.org/img/databases/google-bigquery.png" alt="google-bigquery" border="0" width="200"/>
   <img src="https://superset.apache.org/img/databases/snowflake.png" alt="snowflake" border="0" width="200"/>
   <img src="https://superset.apache.org/img/databases/trino.png" alt="trino" border="0" width="150" />
   <img src="https://superset.apache.org/img/databases/presto.png" alt="presto" border="0" width="200"/>
@@ -150,7 +150,7 @@ Want to add support for your datastore or data engine? Read more [here](https://
 ## Get Involved
 
 - Ask and answer questions on [StackOverflow](https://stackoverflow.com/questions/tagged/apache-superset) using the **apache-superset** tag
-- [Join our community's Slack](http://bit.ly/join-superset-slack)
+- [Join our community's Slack](https://bit.ly/join-superset-slack)
   and please read our [Slack Community Guidelines](https://github.com/apache/superset/blob/master/CODE_OF_CONDUCT.md#slack-community-guidelines)
 - [Join our dev@superset.apache.org Mailing list](https://lists.apache.org/list.html?dev@superset.apache.org). To join, simply send an email to [dev-subscribe@superset.apache.org](mailto:dev-subscribe@superset.apache.org)
 - If you want to help troubleshoot GitHub Issues involving the numerous database drivers that Superset supports, please consider adding your name and the databases you have access to on the [Superset Database Familiarity Rolodex](https://docs.google.com/spreadsheets/d/1U1qxiLvOX0kBTUGME1AHHi6Ywel6ECF8xk_Qy-V9R8c/edit#gid=0)

--- a/docs/docs/contributing/contributing.mdx
+++ b/docs/docs/contributing/contributing.mdx
@@ -11,7 +11,7 @@ The core contributors (or committers) to Superset communicate primarily in the f
 which can be joined by anyone):
 
 - [Mailing list](https://lists.apache.org/list.html?dev@superset.apache.org)
-- [Apache Superset Slack community](http://bit.ly/join-superset-slack)
+- [Apache Superset Slack community](https://bit.ly/join-superset-slack)
 - [GitHub issues](https://github.com/apache/superset/issues)
 - [GitHub pull requests](https://github.com/apache/superset/pulls)
 - [GitHub discussions](https://github.com/apache/superset/discussions)

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -270,7 +270,7 @@ const config = {
               },
               {
                 label: 'Slack',
-                href: 'http://bit.ly/join-superset-slack',
+                href: 'https://bit.ly/join-superset-slack',
               },
               {
                 label: 'Mailing List',

--- a/docs/src/pages/community.tsx
+++ b/docs/src/pages/community.tsx
@@ -26,7 +26,7 @@ import BlurredSection from '../components/BlurredSection';
 
 const communityLinks = [
   {
-    url: 'http://bit.ly/join-superset-slack',
+  url: 'https://bit.ly/join-superset-slack',
     title: 'Slack',
     description: 'Interact with other Superset users and community members.',
     image: 'slack-symbol.jpg',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -277,7 +277,7 @@ exclude = [
 line-length = 88
 indent-width = 4
 
-# Assume Python 3.8
+# Assume Python 3.10
 target-version = "py310"
 
 [tool.ruff.lint]


### PR DESCRIPTION
## Summary
- use HTTPS for Slack links across docs
- fix Google BigQuery image path and alt text
- update Python version comment in Ruff config

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -k 'nothing'` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683ab88521c483229591e2637e4542d4